### PR TITLE
Update 99-toolbox-banner.sh to listen on more than localhost

### DIFF
--- a/scripts/99-toolbox-banner.sh
+++ b/scripts/99-toolbox-banner.sh
@@ -90,4 +90,4 @@ printf 'SSH tip: ssh -L 8000:localhost:8000 user@host\n\n'
 
 # Aliases
 alias start_qwen_studio='cd /opt/qwen-image-studio && uvicorn qwen-image-studio.server:app --reload --host 0.0.0.0 --port 8000'
-alias start_comfy_ui='cd /opt/ComfyUI && python main.py --port 8000 --output-directory $HOME/comfy-outputs --disable-mmap --fp32-vae'
+alias start_comfy_ui='cd /opt/ComfyUI && python main.py --port 8000 --output-directory $HOME/comfy-outputs --disable-mmap --fp32-vae --listen'


### PR DESCRIPTION
While testing out this container, I noticed comfyui isn't listening except on localhost. I have this toolbox on a headless setup, so I need to access it on a different device. This change has comfyui now listening on 0.0.0.0. This will allow using this setup in more diverse situations.